### PR TITLE
Always use LF line endings for shell script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts need LF line endings.
+*.sh text eol=lf


### PR DESCRIPTION
Based on your git config it could happen that the `start.sh` shell script doesn't has LF lineendings.

Therefore the error `exec ./start.sh: no such file or directory` occurs.

This setting makes sure, that this file always gets checked out with LF lineendings.